### PR TITLE
Allow specifying s3 access and secret keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iagitup"
-version = "1.7.0"
+version = "1.8.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='iagitup',
-      version='1.7',
+      version='1.8',
       author='Giovanni Damiola',
       url='https://github.com/gdamdam/iagitup',
       license = "GNU General Public License v3.0",


### PR DESCRIPTION
This change allows passing s3 credentials via command line arguments `--s3-access` and `--s3-secret`.

This way we can call the archiver in non-interactive environments like GitHub actions. Without this change the archiver runs `ia configure` on its first run to receive username and password and setup a configuration file.

The version is bumped to 1.8 and some slight refactoring is made to match the old code with the new version.