### PR TITLE
Setup scheduler

### DIFF
--- a/.github/workflows/job.yml
+++ b/.github/workflows/job.yml
@@ -1,0 +1,42 @@
+on:
+  schedule: [cron: "30 3 * * 2"]
+  workflow_dispatch: {}
+
+jobs:
+  run_archiver:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install .
+        pip install build
+
+    - name: Print version
+      run: python main.py -v
+
+    - name: Archive repos
+      run: |
+        # loop through repositories/list.txt lines. Adding an empty line in case the last line didn't have \n at the end
+        { cat repositories/list.txt; echo; } | while IFS= read -r line || [ -n "$line" ]; do
+          echo "Processing line: $line"
+          if ! python main.py --s3-access "${{ secrets.S3_ACCESS }}" --s3-secret "${{ secrets.S3_SECRET }}" "$line"; then
+            echo "Error processing line: $line" >> failed_lines.txt
+          fi
+        done
+
+        # If any errors occurred, display the log and exit with an error code
+        if [ -f failed_lines.txt ]; then
+          echo "Failed lines:"
+          cat failed_lines.txt
+          exit 1
+        else
+          echo "All lines processed successfully."
+        fi
+

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Just download the _.bundle_ file and run:
     git clone file.bundle
 
 
+## Scheduler
+The workflow defined in [.github/workflows/job.yml](/.github/workflows/job.yml) runs `iagitup` on a schedule. 
+As a one-time setup you need to copy values from https://archive.org/account/s3.php as 
+[GitHub Secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)
+under names `S3_ACCESS` and `S3_SECRET`. Then update the list of repositories in 
+[repositories/list.txt](/repositories/list.txt).
+
 ## License (GPLv3)
 
 Copyright (C) 2017-2018 Giovanni Damiola

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 internetarchive = "^3.6.0"
 gitpython = "^3.1.42"
 markdown2 = "^2.4.12"

--- a/repositories/list.txt
+++ b/repositories/list.txt
@@ -1,0 +1,2 @@
+https://github.com/sindresorhus/awesome
+https://github.com/szabgab/awesome-lists


### PR DESCRIPTION
This change adds a scheduler to the repo using github actions. The scheduler (currently set to run at 3:30 every Tuesday) take a list of repositories from `repositories/list.txt` and calls the archiver on it line by line.

A few notes:

1. The lines are processed in a sequence (not concurrently)
2. Even when there is an error, the scheduler tries to process all lines. The job fails only at the end logging the failed lines.
3. On public repositories if there is no activity on the repo for 60 days Github disables the scheduled workflows. This shouldn't be a problem here as the repo is private.
